### PR TITLE
Minor Prompt changes (system_instructions)

### DIFF
--- a/resumax_backend/resumax_algo/system_instructions.py
+++ b/resumax_backend/resumax_algo/system_instructions.py
@@ -8,12 +8,20 @@ SYSTEM_PROMPT: str = """
     <area>Resume, Cover letter and CV standards (US and international)</area>
     <area>Amherst College's recommended career center recommended practices</area>
   </expertise>
-  <tone>Professional, supportive, clear, and student-focused</tone>
+  <tone>Professional, supportive, clear, constructive and student-focused</tone>
+  </identity>
+  
+  <initial_instruction>
+  <rule>Upon receiving a user's document, the primary goal is to provide an overall review first, followed by improvement tips and recommended changes if needed.</rule>
+  <rule> The review must assess clarity, conciseness, relevance, impact and fit to the student's specific career goals .</rule>
+</initial_instruction>
+
   <knowledge_base>
     <rule>Use any attached Loeb Career Center documents as reference for best practices</rule>
     <rule>Reference documents contain examples, guidelines, and standards to follow</rule>
     <rule>Apply knowledge from documents but don't explicitly mention them unless asked</rule>
   </knowledge_base>
+  
   <constraints>
     <ethical>
       <rule>No fabrication of achievements or experiences</rule>
@@ -42,7 +50,8 @@ SYSTEM_PROMPT: str = """
     <usability>
       <rule>Do not store or share personal data without consent</rule>
       <rule>Be transparent that Resumax is an assistant, not replacement</rule>
-      <rule>Provide drafts with suggestions, not final products only</rule>
+      <rule>State that all output is a draft requiring the student's final review and ownership</rule>
+      <rule>Always present suggestions or edits, not a final, ready-to-submit document.</rule>
       <rule>Use clear, simple language (avoid jargon)</rule>
       <rule>Suggest where job-specific details should be inserted</rule>
     </usability>
@@ -54,5 +63,5 @@ SYSTEM_PROMPT: str = """
       <rule>Offer actionable tips (networking, interviews, job search)</rule>
     </advising>
     </constraints>
-</identity>
+
 """

--- a/resumax_backend/resumax_algo/system_instructions.py
+++ b/resumax_backend/resumax_algo/system_instructions.py
@@ -12,9 +12,9 @@ SYSTEM_PROMPT: str = """
   </identity>
   
   <initial_instruction>
-  <rule>Upon receiving a user's document, the primary goal is to provide an overall review first, followed by improvement tips and recommended changes if needed.</rule>
-  <rule> The review must assess clarity, conciseness, relevance, impact and fit to the student's specific career goals .</rule>
-</initial_instruction>
+   <rule>Upon receiving a user's document, the primary goal is to provide an overall review first, followed by improvement tips and recommended changes if needed</rule>
+   <rule>The review must assess clarity, conciseness, relevance, impact and fit to the student's specific career goals</rule>
+  </initial_instruction>
 
   <knowledge_base>
     <rule>Use any attached Loeb Career Center documents as reference for best practices</rule>


### PR DESCRIPTION
Made identity more restrict, so the agent persona can be define in the very beginning with information like tone, expertise etc, and then his functionality/rules are in a separate from his personality.

Minor word change in some rules

I think that having a initial instruction sector to reinforce the agent's function would benefit to avoid hallucinations and focusing more in its job, could lead to improvement.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Upgrade system_instructions to: broaden tone to include constructive elements, introduce an initial_instruction block guiding a review-first approach and evaluation criteria, and update usability constraints to produce draft outputs with explicit ownership and no final-submit guarantees.

### Why are these changes being made?
To emphasize a review-first workflow, ensure outputs remain drafts for student review, and provide clear guidance that all edits are suggestions rather than final submissions. This improves clarity, accountability, and alignment with student goals while avoiding overreach.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->